### PR TITLE
feat: showcase modals and resizable windows

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -16,6 +16,9 @@
           <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
             <button class="menu-item" data-action="spawn-left" role="menuitem">New Left Window</button>
             <button class="menu-item" data-action="spawn-right" role="menuitem">New Right Window</button>
+            <div class="menu-sep"></div>
+            <button class="menu-item" data-action="spawn-dockable-modal" role="menuitem">Dockable Modal</button>
+            <button class="menu-item" data-action="spawn-simple-modal" role="menuitem">Simple Modal</button>
           </div>
         </div>
       </div>

--- a/src/ui/js/dnd.js
+++ b/src/ui/js/dnd.js
@@ -1,4 +1,5 @@
 // dnd.js — drag and drop between columns, minimize + close behavior
+import { dockWindow, undockWindow } from "./window.js";
 
 export function findDraggableWin(e) {
   const titlebar = e.target.closest(".titlebar");
@@ -137,6 +138,25 @@ export function initWindowDnD() {
         win.style.height = win.dataset.prevHeight;
         delete win.dataset.prevHeight;
       }
+    }
+  });
+
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest(".js-dock-toggle");
+    if (!btn) return;
+    const win = btn.closest(".miniwin");
+    if (!win) return;
+    if (win.classList.contains("modal")) {
+      dockWindow(win);
+      btn.textContent = "⇱";
+      btn.setAttribute("title", "Undock");
+      btn.setAttribute("aria-label", "Undock");
+    } else {
+      const rect = win.getBoundingClientRect();
+      undockWindow(win, rect);
+      btn.textContent = "⇲";
+      btn.setAttribute("title", "Dock");
+      btn.setAttribute("aria-label", "Dock");
     }
   });
 

--- a/src/ui/js/main.js
+++ b/src/ui/js/main.js
@@ -1,6 +1,6 @@
 import { initWindowDnD } from "./dnd.js";
 import { initSplitter } from "./splitter.js";
-import { createMiniWindowFromConfig, initWindowResize } from "./window.js";
+import { createMiniWindowFromConfig, initWindowResize, mountModal } from "./window.js";
 import { initMenu } from "./menu.js";
 
 // Initialise basic UI helpers
@@ -10,8 +10,12 @@ initWindowResize();
 
 function spawnWindow(cfg) {
   const node = createMiniWindowFromConfig(cfg);
-  const col = document.getElementById(cfg.col === "right" ? "col-right" : "col-left");
-  col.appendChild(node);
+  if (cfg.modal) {
+    mountModal(node);
+  } else {
+    const col = document.getElementById(cfg.col === "right" ? "col-right" : "col-left");
+    col.appendChild(node);
+  }
   return node;
 }
 
@@ -22,6 +26,7 @@ spawnWindow({
   title: "Left Demo",
   col: "left",
   unique: true,
+  resizable: true,
   Elements: [
     { type: "text", text: "This is a generic left window." }
   ]
@@ -33,6 +38,7 @@ spawnWindow({
   title: "Right Demo",
   col: "right",
   unique: true,
+  resizable: true,
   Elements: [
     { type: "text", text: "This is a generic right window." }
   ]
@@ -48,6 +54,7 @@ initMenu((action) => {
       window_type: "window_generic",
       title: `Left Window ${counter}`,
       col: "left",
+      resizable: true,
       Elements: [{ type: "text", text: `Dynamic left window ${counter}.` }]
     });
   }
@@ -58,7 +65,30 @@ initMenu((action) => {
       window_type: "window_generic",
       title: `Right Window ${counter}`,
       col: "right",
+      resizable: true,
       Elements: [{ type: "text", text: `Dynamic right window ${counter}.` }]
+    });
+  }
+  if (action === "spawn-dockable-modal") {
+    counter++;
+    spawnWindow({
+      id: `dockable_${counter}`,
+      window_type: "window_generic",
+      title: `Dockable Modal ${counter}`,
+      modal: true,
+      dockable: true,
+      resizable: true,
+      Elements: [{ type: "text", text: "This modal can dock or undock." }]
+    });
+  }
+  if (action === "spawn-simple-modal") {
+    counter++;
+    spawnWindow({
+      id: `modal_${counter}`,
+      window_type: "window_generic",
+      title: `Simple Modal ${counter}`,
+      modal: true,
+      Elements: [{ type: "text", text: "This modal cannot dock." }]
     });
   }
 });


### PR DESCRIPTION
## Summary
- allow windows to dock or undock via new toggle button
- add dockable and simple modals to demo menu
- make demo windows resizable and support modal mounting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9eabc8ac832cbfba6ac696174c10