### PR TITLE
Add auto-resizing chat input window

### DIFF
--- a/src/ui/js/windows/window_chat.js
+++ b/src/ui/js/windows/window_chat.js
@@ -1,0 +1,47 @@
+import { el } from "../ui.js";
+
+export function render(config = {}, winId) {
+  const log = el("div", { class: "chat-log" });
+
+  const textarea = el("textarea", {
+    class: "input",
+    rows: 1,
+    placeholder: config.placeholder || ""
+  });
+
+  const sendBtn = el(
+    "button",
+    { type: "submit", class: "btn" },
+    [config.sendLabel || "Send"]
+  );
+
+  const form = el("form", { class: "chat-input" }, [textarea, sendBtn]);
+
+  const maxHeight = config.maxInputHeight || Infinity;
+  const baseline = textarea.style.height || "auto";
+  const resize = () => {
+    // Reset to baseline height before measuring to handle deletions
+    textarea.style.height = baseline;
+    let h = textarea.scrollHeight;
+    if (maxHeight !== Infinity) h = Math.min(h, maxHeight);
+    textarea.style.height = `${h}px`;
+  };
+
+  textarea.addEventListener("input", resize);
+
+  // Initialize height based on any pre-filled value
+  setTimeout(resize, 0);
+
+  const container = el("div", { class: "chat-window" }, [log, form]);
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const msg = textarea.value.trim();
+    if (!msg) return;
+    log.appendChild(el("div", {}, [msg]));
+    textarea.value = "";
+    resize();
+  });
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- Implement a chat window module with an input that automatically expands based on its content
- Reset textarea height before measuring to handle deletions and cap growth via optional `maxInputHeight` config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc3ed2e38832cab81a23468f4eac7