### PR TITLE
feat: support configurable label positioning

### DIFF
--- a/src/ui/css/style.css
+++ b/src/ui/css/style.css
@@ -377,3 +377,41 @@ html, body {
 .modal-wrap { position: fixed; inset: 0; display: grid; place-items: center; z-index: 1000; }
 .modal-backdrop { position: absolute; inset: 0; background: var(--backdrop); backdrop-filter: blur(2px); }
 .miniwin.modal { position: fixed; top: 15vh; left: calc(50% - 260px); width: 520px; margin: 0; z-index: 1001; }
+
+/* Generic label positioning for framework rows */
+.row.label-top {
+  display: flex;
+  flex-direction: column;
+}
+
+.row.label-top > .label {
+  margin: 0 0 0.5rem 0;
+  width: auto;
+}
+
+.row.label-top > .value {
+  width: 100%;
+}
+
+.row.label-left {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: start;
+  column-gap: 0.75rem;
+}
+
+.row.label-right {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  align-items: start;
+  column-gap: 0.75rem;
+}
+
+.row.label-none > .label {
+  display: none;
+}
+
+.row.label-none > .value {
+  grid-column: 1 / -1;
+  width: 100%;
+}

--- a/src/ui/js/ui.js
+++ b/src/ui/js/ui.js
@@ -1,6 +1,20 @@
 // ui.js — element factory + basic field registry (inputs + views)
 import { renderListView } from "./fields/list_view.js";
 import { renderFileUpload } from "./fields/file_upload.js";
+
+// normalize config key and apply row class for label position
+export function normalizeLabelPos(cfg) {
+  // prefer snake_case, then camelCase, then default
+  return (cfg && (cfg.label_position ?? cfg.labelPosition)) || "left";
+}
+
+export function applyLabelPosition(rowEl, pos) {
+  const p = (pos || "left").toLowerCase();
+  rowEl.classList.remove("label-top", "label-left", "label-right", "label-none");
+  // treat invalid values as "left"
+  const cls = ["top", "left", "right", "none"].includes(p) ? p : "left";
+  rowEl.classList.add(`label-${cls}`);
+}
 export function el(tag, attrs = {}, children = []) {
   const node = document.createElement(tag);
   for (const [k, v] of Object.entries(attrs)) {
@@ -16,30 +30,14 @@ export function el(tag, attrs = {}, children = []) {
   return node;
 }
 
-export function fieldRow(id, labelText, inputEl, opts = {}) {
-  const { showLabel = true, labelPosition = "left" } = opts;
-  const classes = ["row", `label-${labelPosition}`];
-  if (!showLabel) classes.push("no-label");
-  const labelEl = showLabel ? el("label", { for: id }, [labelText]) : null;
-  const row = el("div", { class: classes.join(" ") }, []);
-  switch (labelPosition) {
-    case "right":
-      row.appendChild(inputEl);
-      if (labelEl) row.appendChild(labelEl);
-      break;
-    case "top":
-      if (labelEl) row.appendChild(labelEl);
-      row.appendChild(inputEl);
-      break;
-    case "bottom":
-      row.appendChild(inputEl);
-      if (labelEl) row.appendChild(labelEl);
-      break;
-    case "left":
-    default:
-      if (labelEl) row.appendChild(labelEl);
-      row.appendChild(inputEl);
-  }
+export function fieldRow(id, labelText, inputEl, cfg = {}) {
+  const row = el("div", { class: "row" });
+  const labelEl = el("label", { for: id, class: "label" }, [labelText]);
+  const valueEl = el("div", { class: "value" }, inputEl ? [inputEl] : []);
+  row.append(labelEl, valueEl);
+  let pos = normalizeLabelPos(cfg);
+  if (cfg.showLabel === false && pos !== "none") pos = "none";
+  applyLabelPosition(row, pos);
   return row;
 }
 

--- a/src/ui/js/windows/window_generic.js
+++ b/src/ui/js/windows/window_generic.js
@@ -7,19 +7,14 @@ export function render(config, winId) {
     const baseId = e.id || (e.name ? e.name.toLowerCase().replace(/\s+/g, "_") : `field_${idx+1}`);
     const id = `${baseId}`;
     const label = e.label || e.name || baseId;
-    const opts = {
-      showLabel: e.showLabel !== false,
-      labelPosition: e.labelPosition || "left",
-    };
-
     if (e.type === "item_list") {
       const listEl = createItemList(config.id || winId, { ...e, id });
-      form.appendChild(fieldRow(id, label, listEl, opts));
+      form.appendChild(fieldRow(id, label, listEl, e));
       return;
     }
 
     const input = Field.create({ ...e, id });
-    form.appendChild(fieldRow(id, label, input, opts));
+    form.appendChild(fieldRow(id, label, input, e));
   });
   form.addEventListener("submit", (e) => e.preventDefault());
   return form;


### PR DESCRIPTION
## Summary
- normalize `label_position` config and apply layout classes
- respect label positioning across fields and lists
- add generic CSS for `label-top`, `label-left`, `label-right`, and `label-none`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d035bc560832c98957fafb5586855