### PR TITLE
Add flexible field width handling and document label positioning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,22 @@ The `el` function is a tiny helper that creates DOM nodes. It accepts a tag name
 
 Each field renderer receives a configuration object and must return an `HTMLElement`. When used inside a window, fields can be declared through the `Elements` array of the window configuration.
 
+### Field Layout and Labels
+`fieldRow` wraps an input element with an optional label. Labels can appear on the left, right, top or bottom by setting `labelPosition`.
+The field value container uses flexbox so controls and any trailing buttons align neatly. By default the main element grows to fill
+available space (`flex: 1 1 auto; min-width: 0`). Set `grow: false` in a field configuration to keep a fixed width.
+
+Example field configuration:
+
+```javascript
+{
+  type: "text_field",
+  label: "Name",
+  labelPosition: "top",
+  grow: false
+}
+```
+
 ## Window System
 
 `createMiniWindowFromConfig` builds movable mini windows. Windows can be modal, docked inside columns, resizable, and include action buttons. New window types are registered with `registerWindowType` and provide a renderer that receives the configuration and window id.

--- a/src/ui/js/ui.js
+++ b/src/ui/js/ui.js
@@ -17,28 +17,43 @@ export function el(tag, attrs = {}, children = []) {
 }
 
 export function fieldRow(id, labelText, inputEl, opts = {}) {
-  const { showLabel = true, labelPosition = "left" } = opts;
+  const { showLabel = true, labelPosition = "left", grow = true } = opts;
   const classes = ["row", `label-${labelPosition}`];
   if (!showLabel) classes.push("no-label");
   const labelEl = showLabel ? el("label", { for: id }, [labelText]) : null;
+  const valueEl = el(
+    "div",
+    {
+      class: "value",
+      style: { display: "flex", alignItems: "center", gap: "8px" }
+    },
+    [inputEl]
+  );
+  if (grow === false) {
+    inputEl.style.flex = "0 0 auto";
+    inputEl.style.minWidth = "initial";
+  } else {
+    inputEl.style.flex = "1 1 auto";
+    inputEl.style.minWidth = 0;
+  }
   const row = el("div", { class: classes.join(" ") }, []);
   switch (labelPosition) {
     case "right":
-      row.appendChild(inputEl);
+      row.appendChild(valueEl);
       if (labelEl) row.appendChild(labelEl);
       break;
     case "top":
       if (labelEl) row.appendChild(labelEl);
-      row.appendChild(inputEl);
+      row.appendChild(valueEl);
       break;
     case "bottom":
-      row.appendChild(inputEl);
+      row.appendChild(valueEl);
       if (labelEl) row.appendChild(labelEl);
       break;
     case "left":
     default:
       if (labelEl) row.appendChild(labelEl);
-      row.appendChild(inputEl);
+      row.appendChild(valueEl);
   }
   return row;
 }

--- a/src/ui/js/windows/window_generic.js
+++ b/src/ui/js/windows/window_generic.js
@@ -10,6 +10,7 @@ export function render(config, winId) {
     const opts = {
       showLabel: e.showLabel !== false,
       labelPosition: e.labelPosition || "left",
+      grow: e.grow,
     };
 
     if (e.type === "item_list") {


### PR DESCRIPTION
## Summary
- Wrap field values in a flexbox container for alignment and spacing
- Allow field configs to disable width growth with `grow: false`
- Document label positioning and field width behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1eac4e8c832c81dac58f3a70bd82