### PR TITLE
feat: support component deregistration

### DIFF
--- a/src/ui/js/components.js
+++ b/src/ui/js/components.js
@@ -11,6 +11,18 @@ export function getComponent(winId, elementId) {
   return registry.get(`${winId}:${elementId}`);
 }
 
+export function deregisterComponent(winId, elementId) {
+  if (elementId) {
+    registry.delete(`${winId}:${elementId}`);
+  } else {
+    for (const key of Array.from(registry.keys())) {
+      if (key.startsWith(`${winId}:`)) {
+        registry.delete(key);
+      }
+    }
+  }
+}
+
 export const bus = new EventTarget();
 
 export function createItemList(winId, cfg) {

--- a/src/ui/js/window.js
+++ b/src/ui/js/window.js
@@ -1,5 +1,6 @@
 // window.js — registry + modal/resize helpers
 import { el } from "./ui.js";
+import { deregisterComponent } from "./components.js";
 import { render as renderGeneric } from "./windows/window_generic.js";
 import { render as renderTextEditor } from "./windows/window_text_editor.js";
 import { render as renderChat } from "./windows/window_chat.js";
@@ -188,3 +189,11 @@ export function initWindowResize() {
     document.addEventListener("pointerup", onUp, { once: true });
   });
 }
+
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".js-close");
+  if (!btn) return;
+  const win = btn.closest(".miniwin");
+  if (!win) return;
+  deregisterComponent(win.dataset.id);
+});


### PR DESCRIPTION
## Summary
- add `deregisterComponent` to remove component APIs from registry
- clear component entries when windows are closed

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4ce64cf8832cbaef6bf3e6e4b622