### PR TITLE
Enable snake_case label position in UI elements

### DIFF
--- a/src/ui/js/ui.js
+++ b/src/ui/js/ui.js
@@ -18,7 +18,8 @@ export function el(tag, attrs = {}, children = []) {
 }
 
 export function fieldRow(id, labelText, inputEl, opts = {}) {
-  const { showLabel = true, labelPosition = "left" } = opts;
+  const showLabel = opts.showLabel !== false;
+  const labelPosition = opts.labelPosition || opts.label_position || "left";
   const classes = ["row", `label-${labelPosition}`];
   if (!showLabel) classes.push("no-label");
   const labelEl = showLabel ? el("label", { for: id }, [labelText]) : null;

--- a/src/ui/js/windows/window_generic.js
+++ b/src/ui/js/windows/window_generic.js
@@ -9,7 +9,7 @@ export function render(config, winId) {
     const label = e.label || e.name || baseId;
     const opts = {
       showLabel: e.showLabel !== false,
-      labelPosition: e.labelPosition || "left",
+      labelPosition: e.labelPosition || e.label_position || "left",
     };
 
     if (e.type === "item_list") {


### PR DESCRIPTION
## Summary
- allow `label_position` in window_generic to set label location
- handle snake_case option in fieldRow helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5ec482f0832c9097b98332d8fdd5