### PR TITLE
Refine menu interactions and tighten default theme

### DIFF
--- a/src/ui/css/style.css
+++ b/src/ui/css/style.css
@@ -13,16 +13,16 @@ html, body {
 
 /* ===== Header & Menu ===== */
 .app-header {
-  padding: 8px 12px;
+  padding: 6px 10px;
   background: linear-gradient(180deg, hsl(var(--h) var(--sat) calc(var(--l-panel) + 2%)), hsl(var(--h) var(--sat) var(--l-panel)));
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   position: relative;
 }
 .app-header .left,
-.app-header .right { display: flex; align-items: center; gap: 10px; }
+.app-header .right { display: flex; align-items: center; gap: 6px; }
 .app-header .right { margin-left: auto; }
 .brand {
   position: absolute;
@@ -37,29 +37,29 @@ html, body {
 .menu { position: relative; }
 .menu-trigger {
   appearance: none; border: 1px solid var(--border); background: hsl(var(--h) var(--sat) var(--l-panel));
-  color: var(--text); border-radius: 10px; padding: 6px 10px; font-size: 12px; cursor: pointer;
+  color: var(--text); border-radius: 8px; padding: 4px 8px; font-size: 12px; cursor: pointer;
 }
 .menu-dropdown {
-  position: absolute; top: calc(100% + 6px); left: 0; min-width: 220px;
+  position: absolute; top: calc(100% + 4px); left: 0; min-width: 220px;
   background: hsl(var(--h) var(--sat) calc(var(--l-panel) - 1%));
-  border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow);
-  padding: 6px; display: none; z-index: 50;
+  border: 1px solid var(--border); border-radius: 10px; box-shadow: var(--shadow);
+  padding: 4px; display: none; z-index: 50;
 }
 .menu-dropdown.open { display: block; }
 .menu-item {
-  display: block; width: 100%; text-align: left; padding: 8px 10px;
-  border-radius: 8px; border: none; background: transparent; color: var(--text);
+  display: block; width: 100%; text-align: left; padding: 6px 8px;
+  border-radius: 6px; border: none; background: transparent; color: var(--text);
   font-size: 12px; cursor: pointer;
 }
 .menu-item:hover { background: hsl(var(--h) var(--sat) var(--l-panel)); }
-.menu-sep { height: 1px; background: var(--border); margin: 6px 2px; }
+.menu-sep { height: 1px; background: var(--border); margin: 4px 1px; }
 
 /* User menu */
 .user-menu .menu-trigger {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 3px 6px;
 }
 .user-menu .avatar {
   width: 24px;
@@ -366,7 +366,7 @@ html, body {
 
 /* ===== List View ===== */
 .list-view { display: flex; flex-direction: column; gap: 4px; width: 100%; }
-.lv-row { display: flex; align-items: center; gap: 8px; padding: 6px; border: 1px solid var(--border); border-radius: 8px; width: 100%; }
+.lv-row { display: flex; align-items: center; gap: 6px; padding: 4px; border: 1px solid var(--border); border-radius: 6px; width: 100%; }
 .lv-row.is-selected { background: var(--panel-sel); border-color: var(--accent); }
 .lv-avatar { flex: 0 0 auto; }
 .lv-main { flex: 1 1 auto; }

--- a/src/ui/css/theme.css
+++ b/src/ui/css/theme.css
@@ -8,11 +8,11 @@
   --txt: 92%;        /* text lightness */
 
   /* Layout & typography */
-  --titlebar-height: 36px;
+  --titlebar-height: 32px;
   --font-size-base: 14px;
   --font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
-  --win-gap-vertical: 12px;
-  --win-gap-horizontal: 16px;
+  --win-gap-vertical: 8px;
+  --win-gap-horizontal: 12px;
 
   --positive-h: 150;
   --negative-h: 10;

--- a/src/ui/js/menu.js
+++ b/src/ui/js/menu.js
@@ -3,6 +3,7 @@ export function initMenu(onAction, triggerId = "menu-trigger", dropdownId = "men
   const trigger = document.getElementById(triggerId);
   const dropdown = document.getElementById(dropdownId);
   if (!trigger || !dropdown) return;
+  const openMenus = window.__openMenus || (window.__openMenus = new Set());
 
   function setInert(el, value) {
     try {
@@ -21,12 +22,23 @@ export function initMenu(onAction, triggerId = "menu-trigger", dropdownId = "men
   }
 
   function open() {
+    openMenus.forEach((fn) => fn());
+    openMenus.clear();
     setInert(dropdown, false);
     dropdown.classList.add("open");
     trigger.setAttribute("aria-expanded", "true");
     dropdown.setAttribute("aria-hidden", "false");
+    const rect = dropdown.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      dropdown.style.left = "auto";
+      dropdown.style.right = "0";
+    } else {
+      dropdown.style.left = "";
+      dropdown.style.right = "";
+    }
     // Optional: send focus into the menu for keyboard users
     focusFirstItem();
+    openMenus.add(close);
   }
 
   function close() {
@@ -42,7 +54,10 @@ export function initMenu(onAction, triggerId = "menu-trigger", dropdownId = "men
     dropdown.classList.remove("open");
     trigger.setAttribute("aria-expanded", "false");
     dropdown.setAttribute("aria-hidden", "true");
+    dropdown.style.left = "";
+    dropdown.style.right = "";
     setInert(dropdown, true);
+    openMenus.delete(close);
   }
 
   // Init state: hidden & inert

--- a/src/ui/js/user_menu.js
+++ b/src/ui/js/user_menu.js
@@ -33,16 +33,28 @@ export function createUserMenu(opts = {}) {
     role: "menu",
     "aria-hidden": "true"
   });
+  const openMenus = window.__openMenus || (window.__openMenus = new Set());
 
   function close() {
     dropdown.classList.remove("open");
     trigger.setAttribute("aria-expanded", "false");
     dropdown.setAttribute("aria-hidden", "true");
+    dropdown.style.left = "";
+    dropdown.style.right = "";
+    openMenus.delete(close);
   }
   function open() {
+    openMenus.forEach((fn) => fn());
+    openMenus.clear();
     dropdown.classList.add("open");
     trigger.setAttribute("aria-expanded", "true");
     dropdown.setAttribute("aria-hidden", "false");
+    const rect = dropdown.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      dropdown.style.left = "auto";
+      dropdown.style.right = "0";
+    }
+    openMenus.add(close);
   }
 
   trigger.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- ensure dropdown menus close any others when opened
- keep menus in view by anchoring to the right edge when necessary
- tighten default theme spacing for a lighter appearance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f60da82d0832c95c33aa6277686d7