### PR TITLE
Scale window action buttons with titlebar size

### DIFF
--- a/src/ui/css/style.css
+++ b/src/ui/css/style.css
@@ -160,7 +160,7 @@ html, body {
 }
 .miniwin.dragging .titlebar { cursor: grabbing; }
 .miniwin .titlebar .title { font-weight: 600; font-size: 14px; letter-spacing: .25px; }
-.miniwin .titlebar .actions { display: flex; gap: 6px; }
+.miniwin .titlebar .actions { display: flex; gap: calc(var(--titlebar-height) / 6); }
 
 .icon-btn {
   appearance: none; border: 1px solid var(--border);
@@ -170,6 +170,12 @@ html, body {
 }
 .icon-btn:hover { color: var(--text); border-color: hsl(var(--h) var(--sat) calc(var(--l-border) + 8%)); }
 .icon-btn:active { transform: translateY(1px); }
+
+.miniwin .titlebar .icon-btn {
+  border-radius: calc(var(--titlebar-height) / 3.6);
+  padding: calc(var(--titlebar-height) / 6) calc(var(--titlebar-height) / 4.5);
+  font-size: calc(var(--titlebar-height) / 3);
+}
 
 .miniwin .content {
   padding: 14px;

--- a/src/ui/css/theme.css
+++ b/src/ui/css/theme.css
@@ -8,7 +8,7 @@
   --txt: 92%;        /* text lightness */
 
   /* Layout & typography */
-  --titlebar-height: 36px;
+  --titlebar-height: calc(var(--font-size-base) * 2.5714);
   --font-size-base: 14px;
   --font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
   --win-gap-vertical: 12px;


### PR DESCRIPTION
## Summary
- Derive title bar height from base font size for consistent scaling
- Size window action buttons and spacing using the title bar height

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689f766e9f78832cad2dd850979ebd26