### PR TITLE
feat: add modular ui framework primitives

### DIFF
--- a/docs/FRAMEWORK.md
+++ b/docs/FRAMEWORK.md
@@ -1,0 +1,60 @@
+# UI Framework Overview
+
+This directory documents the universal vanilla JS UI framework. It provides primitives for windows, forms, lists, modals and async UX.
+
+## Architecture
+- **Window shell** – created via `spawnWindow` and controlled through `WindowController`.
+- **Components** – forms, lists, selects and modals live under `src/ui/components`.
+- **Styles** – baseline CSS in `src/ui/styles`.
+- **Events** – components communicate through callbacks or controller events (no global bus).
+
+## Window Guide
+```js
+import { spawnWindow } from "../src/ui/framework/window.js";
+const win = spawnWindow({ title: "Hello" });
+win.on("resize", b => console.log(b.width));
+```
+- `onOpen`, `onClose`, `onResize` hooks are available in `spawnWindow` options.
+- `win.openModal({ title, content(modal){} })` opens a modal relative to the window.
+
+## Form Guide
+```js
+createForm({
+  target: el,
+  fields:[{ type:"text", key:"name", required:true }],
+  onSubmit: v => console.log(v)
+});
+```
+Field types: `text`, `number`, `select`, `toggle`, `textarea`, `json`.
+Validation errors appear inline and block submission. `json` fields parse to objects.
+
+## List Guide
+```js
+createItemList({
+  target: el,
+  columns:[{ key:"name", label:"Item"}],
+  actions:{ remove(it){...} }
+});
+```
+Lists expose `setItems`, `setLoading`, and `setError` for async flows.
+
+## Modal Guide
+```js
+win.openModal({ title:"Confirm", content(modal){ /* ... */ } });
+```
+Modals supply a `ModalController` with `close`, `setTitle`, `on/emit`.
+
+## Async UX
+- `withAsyncState(promise, { onLoading, onError, onData })`
+- `showToast({ type, message })`
+- `createSpinner({ inline })`
+
+## Select Component
+`createSelect({ target, options, value, onChange })` builds a simple data-bound `<select>`.
+
+## Migration
+Legacy code using ad-hoc DOM and global buses can replace them with the primitives:
+1. Replace manual window DOM with `spawnWindow` to get resize and scrolling.
+2. Swap custom form inputs for `createForm` schema.
+3. Replace global event bus list actions with `actions` callbacks.
+4. Use `openModal` instead of separate window IDs for dialogs.

--- a/docs/examples/entity_manager.html
+++ b/docs/examples/entity_manager.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Entity Manager Example</title>
+  <link rel="stylesheet" href="../../src/ui/styles/window.css" />
+  <link rel="stylesheet" href="../../src/ui/styles/components.form.css" />
+  <link rel="stylesheet" href="../../src/ui/styles/components.list.css" />
+  <link rel="stylesheet" href="../../src/ui/styles/components.modal.css" />
+  <link rel="stylesheet" href="../../src/ui/styles/components.toast.css" />
+  <link rel="stylesheet" href="../../src/ui/styles/components.spinner.css" />
+</head>
+<body>
+<script type="module" src="./entity_manager.js"></script>
+</body>
+</html>

--- a/docs/examples/entity_manager.js
+++ b/docs/examples/entity_manager.js
@@ -1,0 +1,79 @@
+import { spawnWindow } from "../../src/ui/framework/window.js";
+import { createForm } from "../../src/ui/components/form.js";
+import { createItemList } from "../../src/ui/components/list.js";
+import { createSelect } from "../../src/ui/components/select.js";
+import { showToast, withAsyncState } from "../../src/ui/components/toast.js";
+
+export function openEntityManagerWindow(entity) {
+  const win = spawnWindow({
+    id: `entity_${entity?.id || "new"}`,
+    title: entity ? `Entity: ${entity.name}` : "New Entity",
+    resizable: true,
+  });
+  const content = win.getContentEl();
+  const formEl = document.createElement("div");
+  const listEl = document.createElement("div");
+  content.append(formEl, listEl);
+
+  const form = createForm({
+    target: formEl,
+    initial: entity || { enabled: true, extra: {} },
+    fields: [
+      { type: "text", key: "name", label: "Name", required: true },
+      { type: "select", key: "provider", label: "Provider", options: ["A","B"] },
+      { type: "text", key: "base_url", label: "Base URL" },
+      { type: "text", key: "api_key", label: "API Key" },
+      { type: "number", key: "timeout", label: "Timeout (sec)" },
+      { type: "toggle", key: "enabled", label: "Enabled" },
+      { type: "json", key: "extra", label: "Extra (JSON)" },
+    ],
+    submitLabel: "Save",
+    onSubmit: async (values) => {
+      await withAsyncState(new Promise(r => setTimeout(r, 300)), {
+        onLoading: () => showToast({ type: "info", message: "Saving..." }),
+        onError: (e) => showToast({ type: "error", message: String(e) }),
+        onData: () => showToast({ type: "success", message: "Saved" })
+      });
+    }
+  });
+
+  const list = createItemList({
+    target: listEl,
+    columns: [ { key: "name", label: "Item" }, { key: "engine", label: "Engine" } ],
+    actions: {
+      use(item){ showToast({ type: "info", message: `Use ${item.name}` }); },
+      rename(item){
+        win.openModal({
+          title: "Rename Item",
+          content(modal){
+            const wrap = document.createElement("div");
+            modal.body.appendChild(wrap);
+            const f = createForm({
+              target: wrap,
+              fields:[{ type:"text", key:"name", label:"Name", required:true }],
+              initial:{ name: item.name },
+              onSubmit:(vals)=>{ item.name=vals.name; list.setItems(items); modal.close(); }
+            });
+          }
+        });
+      },
+      delete(item){ showToast({ type: "warn", message: `Delete ${item.name}` }); }
+    },
+    getRowId: m => m.id,
+  });
+
+  // Simulate async loading of items
+  let items = [];
+  withAsyncState(new Promise(resolve => setTimeout(()=>resolve([
+    { id: 1, name: "Model 1", engine: "gpt" },
+    { id: 2, name: "Model 2", engine: "bert" },
+  ]), 300)), {
+    onLoading: (l)=> list.setLoading(l),
+    onError: (e)=> list.setError(String(e)),
+    onData: (data)=> { items = data; list.setItems(data); }
+  });
+
+  return win;
+}
+
+openEntityManagerWindow();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "deployable-ui",
+  "version": "1.0.0",
+  "description": "Minimal JavaScript UI framework with demo server",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/smoke.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  }
+}

--- a/src/ui/components/form.js
+++ b/src/ui/components/form.js
@@ -1,0 +1,207 @@
+/**
+ * Schema driven form builder.
+ * @module components/form
+ */
+
+/**
+ * Create a form.
+ * @param {Object} opts
+ * @param {HTMLElement} opts.target
+ * @param {Array} opts.fields
+ * @param {Object} [opts.initial]
+ * @param {string} [opts.submitLabel]
+ * @param {Function} [opts.onSubmit]
+ * @param {Function} [opts.onChange]
+ * @returns {FormController}
+ */
+export function createForm({
+  target,
+  fields,
+  initial = {},
+  submitLabel = "Save",
+  onSubmit,
+  onChange,
+}) {
+  const form = document.createElement("form");
+  form.className = "ui-form";
+  const state = {
+    values: { ...initial },
+    dirty: false,
+    errors: {},
+  };
+
+  const inputs = new Map();
+  const errorEls = new Map();
+
+  function setError(key, msg) {
+    state.errors[key] = msg;
+    const el = errorEls.get(key);
+    if (el) el.textContent = msg || "";
+  }
+
+  function handleChange() {
+    state.dirty = true;
+    onChange?.({ ...state.values }, state.dirty);
+  }
+
+  for (const field of fields) {
+    const row = document.createElement("div");
+    row.className = "form-row";
+    const label = document.createElement("label");
+    label.textContent = field.label || field.key;
+    label.htmlFor = field.key;
+    const inputWrap = document.createElement("div");
+    let input;
+    switch (field.type) {
+      case "number":
+      case "text":
+        input = document.createElement("input");
+        input.type = field.type;
+        break;
+      case "textarea":
+        input = document.createElement("textarea");
+        break;
+      case "select":
+        input = document.createElement("select");
+        (field.options || []).forEach((opt) => {
+          const o = document.createElement("option");
+          o.value = typeof opt === "object" ? opt.value : opt;
+          o.textContent = typeof opt === "object" ? opt.label : opt;
+          input.appendChild(o);
+        });
+        break;
+      case "toggle":
+        input = document.createElement("input");
+        input.type = "checkbox";
+        break;
+      case "json":
+        input = document.createElement("textarea");
+        break;
+      default:
+        throw new Error(`Unknown field type ${field.type}`);
+    }
+    input.id = field.key;
+    input.placeholder = field.placeholder || "";
+    if (field.type === "toggle") {
+      input.checked = initial[field.key] ?? false;
+      state.values[field.key] = input.checked;
+      input.addEventListener("change", () => {
+        state.values[field.key] = input.checked;
+        setError(field.key, "");
+        handleChange();
+      });
+    } else {
+      const initialValue =
+        field.type === "json"
+          ? JSON.stringify(initial[field.key] || {}, null, 2)
+          : initial[field.key] ?? "";
+      input.value = initialValue;
+      state.values[field.key] = initial[field.key];
+      input.addEventListener("input", () => {
+        if (field.type === "json") {
+          try {
+            state.values[field.key] = JSON.parse(input.value || "{}");
+            setError(field.key, "");
+          } catch (e) {
+            setError(field.key, "Invalid JSON");
+          }
+        } else if (field.type === "number") {
+          const v = input.value;
+          state.values[field.key] = v === "" ? null : Number(v);
+        } else {
+          state.values[field.key] = input.value;
+        }
+        handleChange();
+      });
+    }
+    inputs.set(field.key, input);
+    inputWrap.appendChild(input);
+    const err = document.createElement("div");
+    err.className = "error";
+    errorEls.set(field.key, err);
+    row.append(label, inputWrap, err);
+    form.appendChild(row);
+  }
+
+  const footer = document.createElement("div");
+  footer.className = "form-footer";
+  const submit = document.createElement("button");
+  submit.type = "submit";
+  submit.textContent = submitLabel;
+  footer.appendChild(submit);
+  form.appendChild(footer);
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+    onSubmit?.({ ...state.values });
+    state.dirty = false;
+  });
+
+  function validate() {
+    let ok = true;
+    for (const field of fields) {
+      const v = state.values[field.key];
+      if (field.required && (v === undefined || v === "" || v === null)) {
+        setError(field.key, "Required");
+        ok = false;
+        continue;
+      }
+      if (field.validate) {
+        const msg = field.validate(v);
+        if (msg) {
+          setError(field.key, msg);
+          ok = false;
+          continue;
+        }
+      }
+      setError(field.key, "");
+    }
+    return ok;
+  }
+
+  target.appendChild(form);
+
+  return new FormController(state, inputs, errorEls, form);
+}
+
+export class FormController {
+  constructor(state, inputs, errorEls, form) {
+    this._state = state;
+    this._inputs = inputs;
+    this._errorEls = errorEls;
+    this.form = form;
+  }
+  getValues() {
+    return { ...this._state.values };
+  }
+  setValues(obj) {
+    for (const [k, v] of Object.entries(obj)) {
+      const input = this._inputs.get(k);
+      if (!input) continue;
+      if (input.type === "checkbox") {
+        input.checked = Boolean(v);
+      } else if (input.tagName === "TEXTAREA" && typeof v === "object") {
+        input.value = JSON.stringify(v, null, 2);
+      } else {
+        input.value = v;
+      }
+      this._state.values[k] = v;
+    }
+  }
+  setDisabled(bool) {
+    for (const input of this._inputs.values()) input.disabled = bool;
+    this.form.querySelector("button[type=submit]").disabled = bool;
+  }
+  setErrors(map) {
+    for (const [k, msg] of Object.entries(map)) {
+      const el = this._errorEls.get(k);
+      if (el) el.textContent = msg;
+    }
+  }
+  isDirty() {
+    return this._state.dirty;
+  }
+}
+
+export default { createForm };

--- a/src/ui/components/list.js
+++ b/src/ui/components/list.js
@@ -1,0 +1,108 @@
+/** Item list component with per-row actions. */
+
+export function createItemList({
+  target,
+  columns,
+  items = [],
+  actions = {},
+  getRowId,
+}) {
+  const container = document.createElement("div");
+  container.className = "item-list";
+  const table = document.createElement("table");
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+  for (const col of columns) {
+    const th = document.createElement("th");
+    th.textContent = col.label || col.key;
+    headerRow.appendChild(th);
+  }
+  if (Object.keys(actions).length) {
+    const th = document.createElement("th");
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  table.appendChild(tbody);
+  container.appendChild(table);
+
+  const state = { items: [] };
+  function renderRows() {
+    tbody.innerHTML = "";
+    if (state.error) {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.colSpan = columns.length + 1;
+      td.className = "error";
+      td.textContent = state.error;
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    if (state.loading) {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.colSpan = columns.length + 1;
+      td.textContent = "Loading...";
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    if (!state.items.length) {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.colSpan = columns.length + 1;
+      td.textContent = "No items";
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    for (const item of state.items) {
+      const tr = document.createElement("tr");
+      tr.dataset.id = getRowId ? getRowId(item) : undefined;
+      for (const col of columns) {
+        const td = document.createElement("td");
+        td.textContent = item[col.key];
+        tr.appendChild(td);
+      }
+      if (Object.keys(actions).length) {
+        const td = document.createElement("td");
+        for (const [name, fn] of Object.entries(actions)) {
+          const btn = document.createElement("button");
+          btn.textContent = name;
+          btn.addEventListener("click", () => fn(item));
+          td.appendChild(btn);
+        }
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+  }
+  const controller = new ListController(state, renderRows);
+  controller.setItems(items);
+  target.appendChild(container);
+  return controller;
+}
+
+export class ListController {
+  constructor(state, render) {
+    this._state = state;
+    this._render = render;
+  }
+  setItems(items) {
+    this._state.items = items || [];
+    this._state.loading = false;
+    this._render();
+  }
+  setLoading(bool) {
+    this._state.loading = bool;
+    this._render();
+  }
+  setError(msg) {
+    this._state.error = msg;
+    this._render();
+  }
+}
+
+export default { createItemList };

--- a/src/ui/components/modal.js
+++ b/src/ui/components/modal.js
@@ -1,0 +1,65 @@
+/** Simple modal/child window API. */
+
+export function openModal({
+  parentWindow,
+  title = "",
+  size = "md",
+  content,
+  onClose,
+}) {
+  const overlay = document.createElement("div");
+  overlay.className = "modal-overlay";
+  const modalEl = document.createElement("div");
+  modalEl.className = `modal modal-${size}`;
+  const header = document.createElement("div");
+  header.className = "modal-header";
+  const titleEl = document.createElement("span");
+  titleEl.className = "modal-title";
+  titleEl.textContent = title;
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "modal-close";
+  closeBtn.textContent = "×";
+  header.append(titleEl, closeBtn);
+  const body = document.createElement("div");
+  body.className = "modal-body";
+  modalEl.append(header, body);
+  overlay.appendChild(modalEl);
+
+  (parentWindow?.root || document.body).appendChild(overlay);
+
+  const ctrl = new ModalController(overlay, modalEl, header, body);
+  closeBtn.addEventListener("click", () => ctrl.close());
+
+  content?.(ctrl);
+  ctrl.on("close", () => onClose?.());
+  return ctrl;
+}
+
+export class ModalController {
+  constructor(overlay, modal, header, body) {
+    this.overlay = overlay;
+    this.modal = modal;
+    this.header = header;
+    this.body = body;
+    this._events = new Map();
+  }
+  close() {
+    this.emit("close");
+    this._events.clear();
+    this.overlay.remove();
+  }
+  on(name, cb) {
+    if (!this._events.has(name)) this._events.set(name, new Set());
+    this._events.get(name).add(cb);
+  }
+  emit(name, payload) {
+    const set = this._events.get(name);
+    if (set) for (const cb of Array.from(set)) cb(payload);
+  }
+  setTitle(text) {
+    const t = this.header.querySelector(".modal-title");
+    if (t) t.textContent = text;
+  }
+}
+
+export default { openModal };

--- a/src/ui/components/select.js
+++ b/src/ui/components/select.js
@@ -1,0 +1,23 @@
+/** Data-bound select component. */
+export function createSelect({ target, options = [], value, onChange, emptyLabel = "None" }) {
+  const select = document.createElement("select");
+  const emptyOpt = document.createElement("option");
+  emptyOpt.value = "";
+  emptyOpt.textContent = emptyLabel;
+  select.appendChild(emptyOpt);
+  for (const opt of options) {
+    const o = document.createElement("option");
+    o.value = typeof opt === "object" ? opt.value : opt;
+    o.textContent = typeof opt === "object" ? opt.label : opt;
+    select.appendChild(o);
+  }
+  if (value !== undefined) select.value = value;
+  select.addEventListener("change", () => onChange?.(select.value));
+  target.appendChild(select);
+  return {
+    setValue(v) { select.value = v; },
+    getValue() { return select.value; },
+  };
+}
+
+export default { createSelect };

--- a/src/ui/components/spinner.js
+++ b/src/ui/components/spinner.js
@@ -1,0 +1,8 @@
+/** Create a spinner element. */
+export function createSpinner({ inline = false } = {}) {
+  const el = document.createElement("div");
+  el.className = inline ? "spinner-inline" : "spinner";
+  return el;
+}
+
+export default { createSpinner };

--- a/src/ui/components/toast.js
+++ b/src/ui/components/toast.js
@@ -1,0 +1,43 @@
+/** Toast notifications and async helpers. */
+
+const containerId = "toast-container";
+function ensureContainer() {
+  let c = document.getElementById(containerId);
+  if (!c) {
+    c = document.createElement("div");
+    c.id = containerId;
+    c.className = "toast-container";
+    document.body.appendChild(c);
+  }
+  return c;
+}
+
+/** Show a toast message. */
+export function showToast({ type = "info", message, timeoutMs = 3000 }) {
+  const c = ensureContainer();
+  const el = document.createElement("div");
+  el.className = `toast toast-${type}`;
+  el.textContent = message;
+  c.appendChild(el);
+  setTimeout(() => {
+    el.remove();
+    if (!c.children.length) c.remove();
+  }, timeoutMs);
+}
+
+/** Wrap an async function with loading/error callbacks. */
+export async function withAsyncState(promise, { onLoading, onError, onData }) {
+  try {
+    onLoading?.(true);
+    const data = await promise;
+    onData?.(data);
+    return data;
+  } catch (e) {
+    onError?.(e);
+    throw e;
+  } finally {
+    onLoading?.(false);
+  }
+}
+
+export default { showToast, withAsyncState };

--- a/src/ui/framework/window.js
+++ b/src/ui/framework/window.js
@@ -1,0 +1,120 @@
+/**
+ * Window framework providing basic window shell and controller API.
+ * @module framework/window
+ */
+
+import { openModal } from "../components/modal.js";
+
+/**
+ * Spawn a window.
+ * @param {Object} opts
+ * @param {string} opts.id - DOM id for the window
+ * @param {string} [opts.title] - title text
+ * @param {boolean} [opts.resizable=true] - allow resize observer
+ * @param {Function} [opts.mount] - called with content element to mount UI
+ * @param {Function} [opts.onOpen]
+ * @param {Function} [opts.onClose]
+ * @param {Function} [opts.onResize]
+ * @returns {WindowController}
+ */
+export function spawnWindow({
+  id,
+  title = "",
+  resizable = true,
+  mount,
+  onOpen,
+  onClose,
+  onResize,
+}) {
+  const root = document.createElement("div");
+  root.className = "window";
+  if (id) root.id = id;
+
+  const header = document.createElement("div");
+  header.className = "titlebar";
+  const titleEl = document.createElement("span");
+  titleEl.className = "title";
+  titleEl.textContent = title;
+  header.appendChild(titleEl);
+
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "close";
+  closeBtn.textContent = "×";
+  closeBtn.addEventListener("click", () => controller.close());
+  header.appendChild(closeBtn);
+
+  const content = document.createElement("div");
+  content.className = "content";
+
+  root.append(header, content);
+  document.body.appendChild(root);
+
+  const controller = new WindowController(root, header, content);
+
+  if (mount) mount(content, controller);
+  onOpen?.(controller);
+
+  if (resizable && typeof ResizeObserver !== "undefined") {
+    const ro = new ResizeObserver(() => {
+      onResize?.(root.getBoundingClientRect());
+      controller.emit("resize", root.getBoundingClientRect());
+    });
+    ro.observe(root);
+    controller._ro = ro;
+  }
+
+  controller.on("close", () => {
+    onClose?.(controller);
+  });
+
+  return controller;
+}
+
+/** Controller representing a window instance. */
+export class WindowController {
+  constructor(root, header, content) {
+    this.root = root;
+    this.header = header;
+    this.content = content;
+    this._events = new Map();
+  }
+
+  /** Set window title. */
+  setTitle(text) {
+    const t = this.header.querySelector(".title");
+    if (t) t.textContent = text;
+  }
+
+  /** Close the window and cleanup. */
+  close() {
+    this.emit("close");
+    this._events.clear();
+    this._ro?.disconnect();
+    this.root.remove();
+  }
+
+  /** Subscribe to a window-scoped event. */
+  on(name, cb) {
+    if (!this._events.has(name)) this._events.set(name, new Set());
+    this._events.get(name).add(cb);
+    return () => this._events.get(name).delete(cb);
+  }
+
+  /** Emit an event to subscribers. */
+  emit(name, payload) {
+    const set = this._events.get(name);
+    if (set) for (const cb of Array.from(set)) cb(payload);
+  }
+
+  /** Open a modal dialog scoped to this window. */
+  openModal(opts) {
+    return openModal({ parentWindow: this, ...opts });
+  }
+
+  /** Get content element. */
+  getContentEl() {
+    return this.content;
+  }
+}
+
+export default { spawnWindow };

--- a/src/ui/styles/components.form.css
+++ b/src/ui/styles/components.form.css
@@ -1,0 +1,21 @@
+.ui-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ui-form .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ui-form .form-row label {
+  font-weight: bold;
+}
+.ui-form .form-row .error {
+  color: #c00;
+  font-size: 0.8em;
+}
+.ui-form .form-footer {
+  margin-top: 8px;
+  text-align: right;
+}

--- a/src/ui/styles/components.list.css
+++ b/src/ui/styles/components.list.css
@@ -1,0 +1,15 @@
+.item-list table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.item-list th, .item-list td {
+  border-bottom: 1px solid #ddd;
+  padding: 4px 8px;
+  text-align: left;
+}
+.item-list td.error {
+  color: #c00;
+}
+.item-list button {
+  margin-right: 4px;
+}

--- a/src/ui/styles/components.modal.css
+++ b/src/ui/styles/components.modal.css
@@ -1,0 +1,31 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal {
+  background: #fff;
+  min-width: 200px;
+  max-width: 90%;
+  max-height: 90%;
+  display: flex;
+  flex-direction: column;
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background: #eee;
+}
+.modal-body {
+  padding: 8px;
+  overflow: auto;
+}
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/src/ui/styles/components.spinner.css
+++ b/src/ui/styles/components.spinner.css
@@ -1,0 +1,12 @@
+.spinner,
+.spinner-inline {
+  border: 2px solid #ccc;
+  border-top-color: #000;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+}
+.spinner { margin: 20px auto; }
+@keyframes spin { from {transform: rotate(0);} to {transform: rotate(360deg);} }

--- a/src/ui/styles/components.toast.css
+++ b/src/ui/styles/components.toast.css
@@ -1,0 +1,18 @@
+.toast-container {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.toast {
+  padding: 6px 10px;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+}
+.toast-success { background: #4caf50; }
+.toast-info    { background: #2196f3; }
+.toast-warn    { background: #ff9800; }
+.toast-error   { background: #f44336; }

--- a/src/ui/styles/window.css
+++ b/src/ui/styles/window.css
@@ -1,0 +1,30 @@
+/* Basic window layout */
+.window {
+  display: flex;
+  flex-direction: column;
+  min-width: 320px;
+  min-height: 200px;
+  background: var(--ui-bg, #fff);
+  border: 1px solid var(--ui-border, #ccc);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.window .titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background: var(--ui-title-bg, #eee);
+  user-select: none;
+}
+.window .titlebar .title { flex: 1; }
+.window .titlebar .close {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.window .content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px;
+}

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,0 +1,32 @@
+import { JSDOM } from 'jsdom';
+import { spawnWindow } from '../src/ui/framework/window.js';
+import { createForm } from '../src/ui/components/form.js';
+import { createItemList } from '../src/ui/components/list.js';
+import { openModal } from '../src/ui/components/modal.js';
+import { showToast, withAsyncState } from '../src/ui/components/toast.js';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+
+aSyncTest();
+
+async function aSyncTest(){
+  const win = spawnWindow({ title: 'Test' });
+  const formWrap = document.createElement('div');
+  win.getContentEl().appendChild(formWrap);
+  const form = createForm({
+    target: formWrap,
+    fields:[{ type:'text', key:'name', label:'Name', required:true }],
+    onSubmit:()=>{}
+  });
+  // Trigger validation error
+  form.form.dispatchEvent(new dom.window.Event('submit', { cancelable:true }));
+  const listWrap = document.createElement('div');
+  win.getContentEl().appendChild(listWrap);
+  createItemList({ target:listWrap, columns:[{key:'name', label:'Name'}], items:[{name:'A'}], actions:{} });
+  const modal = win.openModal({ title:'Modal', content(){} });
+  modal.close();
+  await withAsyncState(Promise.resolve(), { onLoading:()=>{}, onError:()=>{}, onData:()=>{} });
+  showToast({ type:'info', message:'done', timeoutMs:1 });
+}


### PR DESCRIPTION
## Summary
- implement window shell with controller events and modal support
- add schema-driven forms, item lists, toast notifications, and other components
- document architecture and provide entity manager example

## Testing
- `pytest`
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a0e3b78be0832c9cc6d8cdacce185b